### PR TITLE
Allow returning a ChatResponse Multi in streaming mode

### DIFF
--- a/core/deployment/src/main/java/io/quarkiverse/langchain4j/deployment/AiServicesProcessor.java
+++ b/core/deployment/src/main/java/io/quarkiverse/langchain4j/deployment/AiServicesProcessor.java
@@ -618,14 +618,15 @@ public class AiServicesProcessor {
                 if (!DotNames.MULTI.equals(method.returnType().name())) {
                     continue;
                 }
-                boolean isMultiString = false;
+                boolean isSupportedResponseType = false;
                 if (method.returnType().kind() == Type.Kind.PARAMETERIZED_TYPE) {
                     Type multiType = method.returnType().asParameterizedType().arguments().get(0);
-                    if (DotNames.STRING.equals(multiType.name())) {
-                        isMultiString = true;
+                    if (DotNames.STRING.equals(multiType.name())
+                            || DotNames.CHAT_RESPONSE.equals(multiType.name())) {
+                        isSupportedResponseType = true;
                     }
                 }
-                if (!isMultiString) {
+                if (!isSupportedResponseType) {
                     throw illegalConfiguration("Only Multi<String> is supported as a Multi return type. Offending method is '"
                             + method.declaringClass().name().toString() + "#" + method.name() + "'");
                 }

--- a/core/deployment/src/main/java/io/quarkiverse/langchain4j/deployment/DotNames.java
+++ b/core/deployment/src/main/java/io/quarkiverse/langchain4j/deployment/DotNames.java
@@ -13,6 +13,7 @@ import org.jboss.jandex.DotName;
 
 import dev.langchain4j.agent.tool.Tool;
 import dev.langchain4j.model.chat.listener.ChatModelListener;
+import dev.langchain4j.model.chat.response.ChatResponse;
 import io.quarkiverse.langchain4j.auth.ModelAuthProvider;
 import io.quarkiverse.langchain4j.guardrails.OutputGuardrailAccumulator;
 import io.quarkiverse.langchain4j.response.AiResponseAugmenter;
@@ -62,6 +63,7 @@ public class DotNames {
     public static final DotName CHAT_MODEL_LISTENER = DotName.createSimple(ChatModelListener.class);
     public static final DotName MODEL_AUTH_PROVIDER = DotName.createSimple(ModelAuthProvider.class);
     public static final DotName TOOL = DotName.createSimple(Tool.class);
+    public static final DotName CHAT_RESPONSE = DotName.createSimple(ChatResponse.class);
 
     public static final DotName REGISTER_REST_CLIENT = DotName.createSimple(RegisterRestClient.class);
 

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/aiservice/AiServiceMethodImplementationSupport.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/aiservice/AiServiceMethodImplementationSupport.java
@@ -177,6 +177,10 @@ public class AiServiceMethodImplementationSupport {
         Map<String, Object> templateVariables = getTemplateVariables(methodArgs, methodCreateInfo.getUserMessageInfo());
 
         Type returnType = methodCreateInfo.getReturnType();
+        boolean isMulti = TypeUtil.isMulti(returnType);
+
+        final boolean isStringMulti = (isMulti && returnType instanceof ParameterizedType
+                && TypeUtil.isTypeOf(((ParameterizedType) returnType).getActualTypeArguments()[0], String.class));
         if (TypeUtil.isImage(returnType) || TypeUtil.isResultImage(returnType)) {
             return doImplementGenerateImage(methodCreateInfo, context, systemMessage, userMessage, memoryId, returnType,
                     templateVariables, auditSourceInfo);
@@ -217,7 +221,7 @@ public class AiServiceMethodImplementationSupport {
             Metadata metadata = Metadata.from(userMessage, memoryId, chatMemory);
             AugmentationRequest augmentationRequest = new AugmentationRequest(userMessage, metadata);
 
-            if (!TypeUtil.isMulti(returnType)) {
+            if (!isMulti) {
                 augmentationResult = context.retrievalAugmentor.augment(augmentationRequest);
                 userMessage = (UserMessage) augmentationResult.chatMessage();
             } else {
@@ -247,7 +251,13 @@ public class AiServiceMethodImplementationSupport {
                                 return stream.plug(m -> ResponseAugmenterSupport.apply(m, methodCreateInfo,
                                         new ResponseAugmenterParams((UserMessage) augmentedUserMessage,
                                                 memory, ar, methodCreateInfo.getUserMessageTemplate(),
-                                                templateVariables)));
+                                                templateVariables)))
+                                        .map(resp -> {
+                                            if (!isStringMulti) {
+                                                return resp;
+                                            }
+                                            return ((ChatResponse) resp).aiMessage().text();
+                                        });
                             }
 
                             private List<ChatMessage> messagesToSend(UserMessage augmentedUserMessage,
@@ -297,7 +307,7 @@ public class AiServiceMethodImplementationSupport {
 
         var actualAugmentationResult = augmentationResult;
         var actualUserMessage = userMessage;
-        if (TypeUtil.isMulti(returnType)) {
+        if (isMulti) {
             chatMemory.commit(); // for streaming cases, we really have to commit because all alternatives are worse
             if (methodCreateInfo.getOutputGuardrailsClassNames().isEmpty()) {
                 var stream = new TokenStreamMulti(messagesToSend, toolSpecifications, toolExecutors,
@@ -306,7 +316,13 @@ public class AiServiceMethodImplementationSupport {
                 return stream.plug(m -> ResponseAugmenterSupport.apply(m, methodCreateInfo,
                         new ResponseAugmenterParams(actualUserMessage,
                                 chatMemory, actualAugmentationResult, methodCreateInfo.getUserMessageTemplate(),
-                                Collections.unmodifiableMap(templateVariables))));
+                                Collections.unmodifiableMap(templateVariables))))
+                        .map(resp -> {
+                            if (!isStringMulti) {
+                                return resp;
+                            }
+                            return ((ChatResponse) resp).aiMessage().text();
+                        });
             }
 
             return new TokenStreamMulti(messagesToSend, toolSpecifications, toolExecutors,
@@ -317,7 +333,7 @@ public class AiServiceMethodImplementationSupport {
                         OutputGuardrailResult result;
                         try {
                             result = GuardrailsSupport.invokeOutputGuardrailsForStream(methodCreateInfo,
-                                    new OutputGuardrailParams(AiMessage.from(chunk), chatMemory, actualAugmentationResult,
+                                    new OutputGuardrailParams(chunk.aiMessage(), chatMemory, actualAugmentationResult,
                                             methodCreateInfo.getUserMessageTemplate(),
                                             Collections.unmodifiableMap(templateVariables)),
                                     beanManager, auditSourceInfo);
@@ -354,7 +370,13 @@ public class AiServiceMethodImplementationSupport {
                     .plug(m -> ResponseAugmenterSupport.apply(m, methodCreateInfo,
                             new ResponseAugmenterParams(actualUserMessage,
                                     chatMemory, actualAugmentationResult, methodCreateInfo.getUserMessageTemplate(),
-                                    Collections.unmodifiableMap(templateVariables))));
+                                    Collections.unmodifiableMap(templateVariables))))
+                    .map(resp -> {
+                        if (!isStringMulti) {
+                            return resp;
+                        }
+                        return ((ChatResponse) resp).aiMessage().text();
+                    });
         }
 
         Future<Moderation> moderationFuture = triggerModerationIfNeeded(context, methodCreateInfo, messagesToSend);
@@ -915,7 +937,7 @@ public class AiServiceMethodImplementationSupport {
         Object wrap(Input input, Function<Input, Object> fun);
     }
 
-    private static class TokenStreamMulti extends AbstractMulti<String> implements Multi<String> {
+    private static class TokenStreamMulti extends AbstractMulti<ChatResponse> implements Multi<ChatResponse> {
         private final List<ChatMessage> messagesToSend;
         private final List<ToolSpecification> toolSpecifications;
         private final Map<String, ToolExecutor> toolsExecutors;
@@ -941,14 +963,14 @@ public class AiServiceMethodImplementationSupport {
         }
 
         @Override
-        public void subscribe(MultiSubscriber<? super String> subscriber) {
-            UnicastProcessor<String> processor = UnicastProcessor.create();
+        public void subscribe(MultiSubscriber<? super ChatResponse> subscriber) {
+            UnicastProcessor<ChatResponse> processor = UnicastProcessor.create();
             processor.subscribe(subscriber);
 
             createTokenStream(processor);
         }
 
-        private void createTokenStream(UnicastProcessor<String> processor) {
+        private void createTokenStream(UnicastProcessor<ChatResponse> processor) {
             Context ctxt = null;
             if (switchToWorkerThreadForToolExecution || isCallerRunningOnWorkerThread) {
                 // we create or retrieve the current context, to use `executeBlocking` when required.
@@ -959,8 +981,12 @@ public class AiServiceMethodImplementationSupport {
                     toolsExecutors, contents, context, memoryId, ctxt, switchToWorkerThreadForToolExecution,
                     isCallerRunningOnWorkerThread);
             TokenStream tokenStream = stream
-                    .onPartialResponse(processor::onNext)
-                    .onCompleteResponse(message -> processor.onComplete())
+                    .onPartialResponse(chunk -> processor
+                            .onNext(ChatResponse.builder().aiMessage(AiMessage.builder().text(chunk).build()).build()))
+                    .onCompleteResponse(message -> {
+                        processor.onNext(message);
+                        processor.onComplete();
+                    })
                     .onError(processor::onError);
             // This is equivalent to "run subscription on worker thread"
             if (switchToWorkerThreadForToolExecution && Context.isOnEventLoopThread()) {

--- a/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/aiservice/AiServiceMethodImplementationSupport.java
+++ b/core/runtime/src/main/java/io/quarkiverse/langchain4j/runtime/aiservice/AiServiceMethodImplementationSupport.java
@@ -256,7 +256,12 @@ public class AiServiceMethodImplementationSupport {
                                             if (!isStringMulti) {
                                                 return resp;
                                             }
-                                            return ((ChatResponse) resp).aiMessage().text();
+                                            var chatResponse = (ChatResponse) resp;
+                                            if (chatResponse.metadata() != null
+                                                    && chatResponse.metadata().finishReason() != null) {
+                                                return "";
+                                            }
+                                            return chatResponse.aiMessage().text();
                                         });
                             }
 
@@ -321,7 +326,11 @@ public class AiServiceMethodImplementationSupport {
                             if (!isStringMulti) {
                                 return resp;
                             }
-                            return ((ChatResponse) resp).aiMessage().text();
+                            var chatResponse = (ChatResponse) resp;
+                            if (chatResponse.metadata() != null && chatResponse.metadata().finishReason() != null) {
+                                return "";
+                            }
+                            return chatResponse.aiMessage().text();
                         });
             }
 
@@ -375,7 +384,11 @@ public class AiServiceMethodImplementationSupport {
                         if (!isStringMulti) {
                             return resp;
                         }
-                        return ((ChatResponse) resp).aiMessage().text();
+                        var chatResponse = (ChatResponse) resp;
+                        if (chatResponse.metadata() != null && chatResponse.metadata().finishReason() != null) {
+                            return "";
+                        }
+                        return chatResponse.aiMessage().text();
                     });
         }
 


### PR DESCRIPTION
Allow returning a ChatResponse Multi in streaming mode, otherwise we can't get the metadata and token usage and associate it with a specific request.